### PR TITLE
Use ex_aws config when making upload requests

### DIFF
--- a/lib/arc/storage/s3.ex
+++ b/lib/arc/storage/s3.ex
@@ -40,21 +40,26 @@ defmodule Arc.Storage.S3 do
   defp ensure_keyword_list(map) when is_map(map), do: Map.to_list(map)
 
   # If the file is stored as a binary in-memory, send to AWS in a single request
-  defp do_put(file=%Arc.File{binary: file_binary}, {s3_bucket, s3_key, s3_options}) when is_binary(file_binary) do
+  defp do_put(file = %Arc.File{binary: file_binary}, {s3_bucket, s3_key, s3_options})
+       when is_binary(file_binary) do
+    config = ExAws.Config.new(:s3, Application.get_all_env(:ex_aws))
+
     ExAws.S3.put_object(s3_bucket, s3_key, file_binary, s3_options)
-    |> ExAws.request()
+    |> ExAws.request(config)
     |> case do
-      {:ok, _res}     -> {:ok, file.file_name}
+      {:ok, _res} -> {:ok, file.file_name}
       {:error, error} -> {:error, error}
     end
   end
 
   # Stream the file and upload to AWS as a multi-part upload
   defp do_put(file, {s3_bucket, s3_key, s3_options}) do
+    config = ExAws.Config.new(:s3, Application.get_all_env(:ex_aws))
+
     file.path
     |> ExAws.S3.Upload.stream_file()
     |> ExAws.S3.upload(s3_bucket, s3_key, s3_options)
-    |> ExAws.request()
+    |> ExAws.request(config)
     |> case do
       {:ok, %{status_code: 200}} -> {:ok, file.file_name}
       {:ok, :done} -> {:ok, file.file_name}


### PR DESCRIPTION
## Description

The motivation for this change is to make `arc` library test-able for S3 file uploads.

`arc` already [uses s3 config when building presigned url](https://github.com/Recapped/arc/blob/master/lib/arc/storage/s3.ex#L82), but it doesn't do that when making put object requests to upload files.

The change is to load s3 configs in the same way and pass configs into `ExAws.request/2` ([see docs](https://hexdocs.pm/ex_aws_with_qldb/ExAws.html#request/2)).

I have manually tested this 

## Your checklist for this pull request

- [x] Have you picked reviewers?
- [x] Are there tests to cover the changes?
- [x] Have you manually QA'd the changes?
- [x] Does the code consider failures (the non-happy path)?
